### PR TITLE
Bringing fork up to date

### DIFF
--- a/chrome_extension/background/event.js
+++ b/chrome_extension/background/event.js
@@ -243,7 +243,7 @@ mooltipassEvent.isMooltipassUnlocked = function()
 	var noteId = 'mpNotUnlocked.'+mooltipassEvent.notificationCount.toString();
 
 	// Check that the Mooltipass app is installed and enabled
-	if (!mooltipass.device.connectedToExternalApp && (!mooltipass.device._app || mooltipass.device._app['enabled'] !== true))
+	if (!mooltipass.device.emulation_mode && !mooltipass.device.connectedToExternalApp && (!mooltipass.device._app || mooltipass.device._app['enabled'] !== true))
 	{
 		//console.log('notify: mooltipass app not ready');
 

--- a/chrome_extension/vendor/mooltipass/device.js
+++ b/chrome_extension/vendor/mooltipass/device.js
@@ -10,7 +10,7 @@ mooltipass.device = mooltipass.device || {};
 /**
  * Mooltipass emulation vars
  */
-mooltipass.device.emulation_mode = true
+mooltipass.device.emulation_mode = false
 mooltipass.device.emulation_credentials = []
 //mooltipass.device.emulation_credentials.push({"domain":"limpkin.fr", "login":"lapin", "password":"test"});
 

--- a/chrome_extension/vendor/mooltipass/mcCombinations.js
+++ b/chrome_extension/vendor/mooltipass/mcCombinations.js
@@ -1081,7 +1081,7 @@ mcCombinations.prototype.postDetected = function( details ) {
 				}
 
 				// Only update if they differ from our database values (and if new values are filled in)
-				if ( storedUsernameValue != usernameValue || storedPasswordValue != passwordValue && (usernameValue != '' && passwordValue != '') ) {
+				if ( ((storedUsernameValue != usernameValue) || (storedPasswordValue != passwordValue)) && (usernameValue != '' && passwordValue != '') ) {
 					var url = document.location.origin;
 					chrome.runtime.sendMessage({
 						'action': 'update_notify',

--- a/chrome_extension/vendor/mooltipass/moolticute.js
+++ b/chrome_extension/vendor/mooltipass/moolticute.js
@@ -336,4 +336,5 @@ moolticute.websocket = {
         return output;
     }
 };
-moolticute.websocket.connect();
+/* First call to connect */
+setTimeout(function() {if(!mooltipass.device.emulation_mode) moolticute.websocket.connect();}, 1000);


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is compliant with the contributing guidelines (if not, please describe why): code is fully documented and if possible a .md file is made.
- [ ] The PR text includes a **detailed explanation** (more than 50 chars)
- [ ] I have thoroughly tested my contribution.

\<Description of and rational behind this PR\>

**In case of a PR concerning the Mooltipass extension:**  
The following test procedure should be done, in the following order.  
  
1) Recall functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass  
- accept the credentials sending request  
- make sure you are logged in  
  
2) Storage functionality test (Mooltipass unlocked):  
- visit a website you don't have credentials for  
- fill the username and password field, submit  
- make sure the mooltipass prompts you for password storage **once**  
- accept the credentials storage request  
- run test 1) to make sure credentials are correctly stored  
  
3) Cancel functionality test (Mooltipass unlocked):  
- visit a website you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request, close the tab  
- make sure the prompt gets removed on the mooltipass  
  
4) Credentials requests queue test (Mooltipass **locked**)  
- visit a website you have credentials for  
- unlock your mooltipass  
- make sure you get prompted by your mooltipass   
  
5) Credentials requests queue test (Mooltipass unlocked)  
- visit a website A you have credentials for  
- make sure you get prompted by your mooltipass   
- do not accept the credentials sending request  
- visit a website B you have credentials for  
- close the tab containing the website A  
- make sure the first prompt is cancelled on the mooltipass  
- make sure another prompt for website B is displayed on the mooltipass  
   